### PR TITLE
Removing msgpack from message.py and requirements

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -24,8 +24,6 @@ Required
 
 `Pika <http://pika.readthedocs.org>`_ is an amqp library for python 2 (not 3.x).
 
-`msgpack <http://msgpack.org>`_ is used to store payloads in messages transferred via amqp.
-
 `PyYAML <http://pyyaml.org>`_ is used to read yaml formatted configuration files.
 It could in principle (and perhaps should) be moved to "optional" status (since it is possible to run several aspects without a config file, and json based config files would be easy to use.
 Nevertheless, PyYAML is pervasive and we've had no motivation to refactor to make it cleanly optional.
@@ -87,7 +85,7 @@ For the complete experience, you would run the following three commands (the las
 This will install the local dripline source into your same virtual environment. If you are going to develop on the source replace the last line with the following two:
 
 .. code-block:: bash
-	
+
         $ pip install pika msgpack-python PyYAML [whichever optionals you want]
 		$ python setup.py develop
 

--- a/doc/wire_protocol.txt
+++ b/doc/wire_protocol.txt
@@ -27,7 +27,7 @@ Message Standards
 Encoding
 --------
 
-The AMQP message body should be formatted in either [JSON](http://json.org) or [msgpack](http://msgpack.org).  The encoding (`application/json` or `application/msgpack`) should be specified in the `content_encoding` field of the AMQP message.
+The AMQP message body should be formatted in either [JSON](http://json.org).  The encoding (`application/json`) should be specified in the `content_encoding` field of the AMQP message.
 
 Structure
 ---------
@@ -43,39 +43,39 @@ Structure
 | `sender_info.commit` | string | All | Git commit of the sender package |
 | `sender_info.hostname` | string | All | Name of the host computer that sends the message |
 | `sender_info.username` | string | All | User responsible for sending the message |
-| `payload` | any | | The content of the message |  
-| `retcode` | integer | Reply | See [table below](#return-codes) |  
+| `payload` | any | | The content of the message |
+| `retcode` | integer | Reply | See [table below](#return-codes) |
 
 Return Codes
 ------------
 
 The following table is direct from the current error codes as defined in dripline. I think I'd like to make some changes, but I haven't thought them through very much. Just brainstorming, I'm thinking 0-99 for success and warnings; 100-199 for errors related to AMQP (ex, errors caught from library); 200-299 for hardware related errors (interaction problems, driver exceptions, etc.); 300-399 shouldn't be 'dripline' but 'consumer', the several encoding/decoding related exceptions could probably be combined. I should discuss this with Noah w.r.t. hornet and mantis.
 
-| Code | Description |  
-|:----:|:------------|  
-| 0    | Success     |  
-| 1-99 | Unassigned, non-error warnings|  
-| 100  | Generic AMQP Related Error |  
-| 101  | AMQP Connection Error |  
-| 102  | AMQP Routing Key Error |  
-|103-199| Unallocated AMQP Errors |  
-| 200  | Generic Hardware Related Error |  
-| 201  | Hardware Connection Error |  
-| 202  | Hardware no Response Error |  
-|203-299| Unallocated Hardware Errors|  
-| 300  | Generic Dripline Error |  
-| 301  | No message encoding error |  
-| 302  | Decoding Failed Error |  
-| 303  | Payload related error |  
-| 304  | Value Error |  
-| 305  | Timeout |  
-|306-399| Unallocated Dripline errors|  
-| 400  | Generic Database Error |    
-| 500  | Generic DAQ Error |    
-| 501  | DAQ Not Enabled |    
-| 502  | DAQ Running |  
-| 600-998 | Unallocated |  
-| 999 | Unhandled Error |  
+| Code | Description |
+|:----:|:------------|
+| 0    | Success     |
+| 1-99 | Unassigned, non-error warnings|
+| 100  | Generic AMQP Related Error |
+| 101  | AMQP Connection Error |
+| 102  | AMQP Routing Key Error |
+|103-199| Unallocated AMQP Errors |
+| 200  | Generic Hardware Related Error |
+| 201  | Hardware Connection Error |
+| 202  | Hardware no Response Error |
+|203-299| Unallocated Hardware Errors|
+| 300  | Generic Dripline Error |
+| 301  | No message encoding error |
+| 302  | Decoding Failed Error |
+| 303  | Payload related error |
+| 304  | Value Error |
+| 305  | Timeout |
+|306-399| Unallocated Dripline errors|
+| 400  | Generic Database Error |
+| 500  | Generic DAQ Error |
+| 501  | DAQ Not Enabled |
+| 502  | DAQ Running |
+| 600-998 | Unallocated |
+| 999 | Unhandled Error |
 
 Software Implementations
 ========================

--- a/dripline/core/message.py
+++ b/dripline/core/message.py
@@ -162,10 +162,10 @@ class Message(dict, object):
 
     @classmethod
     def from_encoded(cls, msg, encoding):
-        if encoding.endswith('json'):
-            return cls.from_json(msg)
-        elif encoding is None:
+        if encoding is None:
             logger.warning("No encoding is provided: will try with json")
+            return cls.from_json(msg)
+        elif encoding.endswith('json'):
             return cls.from_json(msg)
         else:
             raise exceptions.DriplineDecodingError('encoding <{}> not recognized'.format(encoding))
@@ -176,10 +176,10 @@ class Message(dict, object):
         return json.dumps(temp_dict)
 
     def to_encoding(self, encoding):
-        if encoding.endswith('json'):
-            return self.to_json()
-        elif encoding is None:
+        if encoding is None:
             logger.warning("No encoding is provided: will try with json")
+            return self.to_json()
+        elif encoding.endswith('json'):
             return self.to_json()
         else:
             raise ValueError('encoding <{}> not recognized'.format(encoding))

--- a/dripline/core/message.py
+++ b/dripline/core/message.py
@@ -17,9 +17,6 @@ import pwd
 import socket
 import traceback
 
-# 3rd party libs
-#import msgpack
-
 # internal imports
 from . import constants
 from . import exceptions
@@ -153,13 +150,6 @@ class Message(dict, object):
             raise ValueError('msgtype must be defined as in spec!')
 
     @classmethod
-    def from_msgpack(cls, msg):
-        raise exceptions.DriplineDeprecated('decoding message from msgpack is deprecated')
-        #message_dict = msgpack.unpackb(msg)
-        #message = cls.from_dict(message_dict)
-        #return message
-
-    @classmethod
     def from_json(cls, msg):
         logger.debug('original msg was: {}'.format(msg))
         try:
@@ -174,19 +164,11 @@ class Message(dict, object):
     def from_encoded(cls, msg, encoding):
         if encoding.endswith('json'):
             return cls.from_json(msg)
-        elif encoding.endswith('msgpack'):
-            logger.warning('received message encoded with msgpack, this is deprecated')
-            return cls.from_msgpack(msg)
+        elif encoding is None:
+            logger.warning("No encoding is provided: will try with json")
+            return cls.from_json(msg)
         else:
             raise exceptions.DriplineDecodingError('encoding <{}> not recognized'.format(encoding))
-
-    def to_msgpack(self):
-        raise exceptions.DriplineDeprecated('encoding message to msgpack is deprecated')
-        #logger.warning('encoding message to msgpack, this is deprecated')
-        #logger.warning('traceback for that call is:\n{}'.format(traceback.format_exc()))
-        #temp_dict = self.copy()
-        #temp_dict.update({'msgtype': self.msgtype})
-        #return msgpack.packb(temp_dict)
 
     def to_json(self):
         temp_dict = self.copy()
@@ -196,8 +178,9 @@ class Message(dict, object):
     def to_encoding(self, encoding):
         if encoding.endswith('json'):
             return self.to_json()
-        elif encoding.endswith("msgpack"):
-            return self.to_msgpack()
+        elif encoding is None:
+            logger.warning("No encoding is provided: will try with json")
+            return self.to_json()
         else:
             raise ValueError('encoding <{}> not recognized'.format(encoding))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ gnureadline==6.3.3
 ipdb==0.8.1
 ipython==4.0.0
 ipython-genutils==0.1.0
-msgpack-python==0.4.6
 path.py==8.1.2
 pexpect==4.0.1
 pickleshare==0.5

--- a/requirements_sphinx.txt
+++ b/requirements_sphinx.txt
@@ -15,7 +15,6 @@ gnureadline==6.3.3
 ipdb==0.8.1
 ipython==4.0.0
 ipython-genutils==0.1.0
-msgpack-python==0.4.6
 path.py==8.1.2
 pexpect==4.0.1
 pickleshare==0.5

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name='dripline',
     version=verstr,
     packages=['dripline','dripline/core'],
-    install_requires=['pika>=0.9.8,<0.10', 'PyYAML', 'msgpack-python'],
+    install_requires=['pika>=0.9.8,<0.10', 'PyYAML'],
     extras_require=extras_require,
     url='http://www.github.com/project8/dripline',
     tests_require=['pytest'],


### PR DESCRIPTION
Removing msgpack from message.py.
The presence of json encoding is done first (if a new formatting is set, it should be added before the ```elif encoding is None``` test).
If no encoding is defined, it will try with json.
If an encoding is unknown, it will stop.

I also removed msgpack from requirements: will need to remove them from dragonfly too.