### PR TITLE
refactor scheduler

### DIFF
--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -201,9 +201,9 @@ class Endpoint(object):
         result = None
         attribute = kwargs.get('routing_key_specifier', [''][0]).replace('-','_')
         if attribute:
-            if hasattr(self, attribute):
+            try:
                 result = getattr(self, attribute)
-            else:
+            except AttributeError:
                 raise exceptions.DriplineValueError('{}({}) has no <{}> attribute'.format(self.name, self.__class__.__name__, attribute))
         else:
             result = self.on_get()
@@ -220,9 +220,9 @@ class Endpoint(object):
             attribute = kwargs['routing_key_specifier'].replace('-','_')
             value = args[0]
         if attribute:
-            if hasattr(self, attribute):
+            try:
                 setattr(self, attribute, value)
-            else:
+            except AttributeError:
                 raise exceptions.DriplineValueError('{}({}) has no <{}> attribute'.format(self.name, self.__class__.__name__, attribute))
         else:
             result = self.on_set(value[0])
@@ -282,10 +282,10 @@ class Endpoint(object):
             #     logger.debug('{} is a Spimescape service: skipped!'.format(key))
             #     continue
             logger.info('Setting condition of {}: {}'.format(key,args))
-            if hasattr(endpoint, '_set_condition'):
+            try:
                 result = getattr(endpoint, '_set_condition')(*args, **kwargs)
                 print(result)
-            else:
+            except AttributeError:
                 logger.debug('{} has no _set_condition attribute, skipped!'.format(key))
         return None
 

--- a/dripline/core/provider.py
+++ b/dripline/core/provider.py
@@ -65,28 +65,34 @@ class Provider(Endpoint):
         raise AttributeError('endpoint name list cannot be directly modified')
 
     @property
-    def logging_status(self):
+    def schedule_status(self):
         if isinstance(self, Spime):
-            return Spime.logging_status.fget(self)
-        logger.info('getting logging status for endpoints of: {}'.format(self.name))
+            return Spime.schedule_status.fget(self)
+        logger.info('getting logging schedule status for endpoints of: {}'.format(self.name))
         results = []
         for (name,endpoint) in self._endpoints.items():
+            if name == self.name:
+                logger.debug('skipping self')
+                continue
             logger.debug('getting status of: {}'.format(endpoint.name))
-            if hasattr(endpoint, 'logging_status'):
-                results.append((name,endpoint.logging_status))
+            if hasattr(endpoint, 'schedule_status'):
+                results.append((name,endpoint.schedule_status))
         return results
-    @logging_status.setter
-    def logging_status(self, value):
+    @schedule_status.setter
+    def schedule_status(self, value):
         if isinstance(self, Spime):
-            Spime.logging_status.fset(self, value)
+            Spime.schedule_status.fset(self, value)
             return
-        logger.info('setting logging status for endpoints of: {}'.format(self.name))
+        logger.info('setting logging schedule status for endpoints of: {}'.format(self.name))
         results = []
         for (name,endpoint) in self._endpoints.items():
+            if name == self.name:
+                logger.debug('skipping self')
+                continue
             logger.debug('trying to set for: {}'.format(endpoint.name))
-            if hasattr(endpoint, 'logging_status'):
+            if hasattr(endpoint, 'schedule_status'):
                 try:
-                    results.append((name, setattr(endpoint, 'logging_status', value)))
+                    results.append((name, setattr(endpoint, 'schedule_status', value)))
                 except Warning as err:
                     logger.warning('got warning: {}'.format(str(err)))
         return results

--- a/dripline/core/provider.py
+++ b/dripline/core/provider.py
@@ -64,6 +64,16 @@ class Provider(Endpoint):
     def endpoint_names(self, value):
         raise AttributeError('endpoint name list cannot be directly modified')
 
+    # Redirect logging_status to schedule_status for backwards compatibility
+    @property
+    def logging_status(self):
+        logger.warning('use of logging_status is deprecated, switch to using schedule_status')
+        return self.schedule_status
+    @logging_status.setter
+    def logging_status(self, value):
+        logger.warning('use of logging_status is deprecated, switch to using schedule_status')
+        self.schedule_status = value
+
     @property
     def schedule_status(self):
         if isinstance(self, Spime):
@@ -91,6 +101,9 @@ class Provider(Endpoint):
                 continue
             logger.debug('trying to set for: {}'.format(endpoint.name))
             if hasattr(endpoint, 'schedule_status'):
+                if endpoint.schedule_interval == -1:
+                    logger.debug('skipping scheduling {} because schedule_interval set to -1'.format(endpoint.name))
+                    continue
                 try:
                     results.append((name, setattr(endpoint, 'schedule_status', value)))
                 except Warning as err:

--- a/dripline/core/provider.py
+++ b/dripline/core/provider.py
@@ -84,9 +84,11 @@ class Provider(Endpoint):
             if name == self.name:
                 logger.debug('skipping self')
                 continue
-            logger.debug('getting status of: {}'.format(endpoint.name))
-            if hasattr(endpoint, 'schedule_status'):
+            try:
                 results.append((name,endpoint.schedule_status))
+                logger.debug('got <schedule_status> for: {}'.format(endpoint.name))
+            except AttributeError:
+                logger.debug('{} has no <schedule_status> attribute, skipping'.format(endpoint.name))
         return results
     @schedule_status.setter
     def schedule_status(self, value):
@@ -99,15 +101,16 @@ class Provider(Endpoint):
             if name == self.name:
                 logger.debug('skipping self')
                 continue
-            logger.debug('trying to set for: {}'.format(endpoint.name))
-            if hasattr(endpoint, 'schedule_status'):
+            try:
                 if endpoint.schedule_interval == -1:
                     logger.debug('skipping scheduling {} because schedule_interval set to -1'.format(endpoint.name))
                     continue
-                try:
-                    results.append((name, setattr(endpoint, 'schedule_status', value)))
-                except Warning as err:
-                    logger.warning('got warning: {}'.format(str(err)))
+                results.append((name, setattr(endpoint, 'schedule_status', value)))
+                logger.debug('set <schedule_status> for: {}'.format(endpoint.name))
+            except AttributeError:
+                logger.debug('{} has no <schedule_status> attribute, skipping'.format(endpoint.name))
+            except Warning as err:
+                logger.warning('got warning: {}'.format(str(err)))
         return results
 
     @property

--- a/dripline/core/scheduler.py
+++ b/dripline/core/scheduler.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 __docformat__ = 'reStructuredText'
 
 import abc
-import datetime
 import logging
 import traceback
 
@@ -24,138 +23,34 @@ class Scheduler(object):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self,
-                 log_interval=0.,
-                 max_interval=0,
-                 max_fractional_change=0,
-                 alert_routing_key='sensor_value',
+                 schedule_interval=0.,
                  **kwargs):
         '''
-        log_interval (float): minimum time in seconds between sequential log events (note that this may or may not produce an actual log broadcast)
-        max_interval (float): If > 0, any log event exceding this number of seconds since the last broadcast will trigger a broadcast.
-        max_fractional_change (float): If > 0, any log event which produces a value which differs from the previous value by more than this amount (expressed as a fraction, ie 10% change is 0.1) will trigger a broadcast
-        alert_routing_key (str): routing key for the alert message send when broadcasting a logging event result. The default value of 'sensor_value' is valid for DataLoggers which represent physical quantities being stored to the slow controls database tables
-
+        schedule_interval (float): time in seconds between scheduled events
         '''
-        self.alert_routing_key=alert_routing_key + '.' + self.name
-        self._log_interval = log_interval
-        self._max_interval = max_interval
-        self._max_fractional_change = max_fractional_change
-        self._is_logging = False
+        self._schedule_interval = schedule_interval
+        self._is_looping = False
         self._timeout_handle = None
 
-        self._last_log_time = None
-        self._last_log_value = None
-
-    def get_value(self):
-        raise NotImplementedError('get value in derrived class')
-
-    def store_value(self, severity=None, value=None):
-        raise NotImplementedError('store value in derrived class')
+    def scheduled_action(self):
+        raise NotImplementedError("scheduled_action must be defined in derived class")
 
     @property
-    def log_interval(self):
-        return self._log_interval
-    @log_interval.setter
-    def log_interval(self, value):
+    def schedule_interval(self):
+        return self._schedule_interval
+    @schedule_interval.setter
+    def schedule_interval(self, value):
         value = float(value)
         if value < 0:
-            raise ValueError('Log interval cannot be < 0')
-        self._log_interval = value
+            raise ValueError('Schedule loop interval cannot be < 0')
+        self._schedule_interval = value
 
     @property
-    def max_interval(self):
-        return self._max_interval
-    @max_interval.setter
-    def max_interval(self, value):
-        value = float(value)
-        if value < 0:
-            raise ValueError('max log interval cannot be < 0')
-        self._max_interval = value
-
-    @property
-    def max_fractional_change(self):
-        return self._max_fractional_change
-    @max_fractional_change.setter
-    def max_fractional_change(self, value):
-        value = float(value)
-        if value < 0:
-            raise ValueError('fractional change cannot be < 0')
-        self._max_fractional_change = value
-
-    def _conditionally_send(self, to_send):
-        '''
-        consider sending value, but only if a send condition is met
-        '''
-        this_value = None
-        try:
-            this_value = float(to_send['value_raw'])
-        except (TypeError, ValueError):
-            pass
-        if self._last_log_value is None:
-            logger.debug("log b/c no last log")
-        elif (datetime.datetime.utcnow() - self._last_log_time).seconds > self._max_interval:
-            logger.debug('log b/c too much time')
-        elif (abs(self._last_log_value - this_value)/self._last_log_value) > self.max_fractional_change:
-            logger.debug('log b/c change is too large')
-        else:
-            logger.debug('no log condition met, not logging')
-            return
-        self.store_value(to_send, severity=self.alert_routing_key)
-        self._last_log_time = datetime.datetime.utcnow()
-        self._last_log_value = this_value
-
-    def _log_a_value(self):
-        try:
-            to_send = self.get_value()
-            if to_send is None:
-                logger.warning('get returned None')
-                if hasattr(self, 'name'):
-                    logger.warning('for: {}'.format(self.name))
-            self._conditionally_send(to_send)
-        except UserWarning:
-            logger.warning('get returned None')
-            if hasattr(self, 'name'):
-                logger.warning('for: {}'.format(self.name))
-        except Exception as err:
-            logger.error('got a: {}'.format(str(err)))
-            logger.error('traceback follows:\n{}'.format(traceback.format_exc()))
-        logger.info('value sent')
-        if (self._log_interval <= 0) or (not self._is_logging):
-            return
-        self._timeout_handle = self.service._connection.add_timeout(self._log_interval, self._log_a_value)
-
-    def _stop_loop(self):
-        try:
-            self._is_logging = False
-            self.service._connection.remove_timeout(self._timeout_handle)
-        except Warning:
-            pass
-        except:
-            logger.error('something went wrong stopping')
-            raise
-
-    def _start_loop(self):
-        self._is_logging = True
-        if self._log_interval <= 0:
-            raise Warning("log interval must be > 0")
-        else:
-            self.service._connection.remove_timeout(self._timeout_handle)
-            self._log_a_value()
-            logger.info("log loop started")
-
-    def _restart_loop(self):
-        try:
-            self._stop_loop()
-        except Warning:
-            pass
-        self._start_loop()
-
-    @property
-    def logging_status(self):
-        return self._is_logging
-    @logging_status.setter
-    def logging_status(self, value):
-        logger.info('setting logging state to: {}'.format(value))
+    def schedule_status(self):
+        return self._is_looping
+    @schedule_status.setter
+    def schedule_status(self, value):
+        logger.info('setting schedule state to: {}'.format(value))
         if value in ['start', 'on']:
             self._start_loop()
         elif value in ['stop', 'off']:
@@ -163,4 +58,46 @@ class Scheduler(object):
         elif value in ['restart']:
             self._restart_loop()
         else:
-            raise ValueError('unrecognized logger status setting')
+            raise ValueError('unrecognized schedule state setting')
+
+    def single_schedule(self, delay):
+        if self._is_looping:
+            logger.warning('single_schedule will break existing schedule loop')
+            self._stop_loop()
+        self._timeout_handle = self.service._connection.add_timeout(delay, self._process_schedule)
+
+    def _process_schedule(self):
+        logger.info("beginning scheduled sequence")
+        try:
+            result = self.scheduled_action()
+        except Exception as err:
+            logger.error('got a: {}'.format(str(err)))
+            logger.error('traceback follows:\n{}'.format(traceback.format_exc()))
+        logger.debug("scheduled sequence complete")
+        if self._is_looping and (self._schedule_interval > 0):
+            self._timeout_handle = self.service._connection.add_timeout(self._schedule_interval, self._process_schedule)
+
+    def _start_loop(self):
+        if self._schedule_interval <= 0:
+            raise Warning("schedule loop interval must be > 0")
+        self.service._connection.remove_timeout(self._timeout_handle)
+        self._is_looping = True
+        self._process_schedule()
+        logger.info("schedule loop started")
+
+    def _stop_loop(self):
+        try:
+            self.service._connection.remove_timeout(self._timeout_handle)
+            self._is_looping = False
+        except Warning:
+            pass
+        except:
+            logger.error('something went wrong stopping')
+            raise
+
+    def _restart_loop(self):
+        try:
+            self._stop_loop()
+        except Warning:
+            pass
+        self._start_loop()

--- a/dripline/core/scheduler.py
+++ b/dripline/core/scheduler.py
@@ -44,6 +44,9 @@ class Scheduler(object):
         if value < 0:
             raise ValueError('Schedule loop interval cannot be < 0')
         self._schedule_interval = value
+        if self.schedule_status:
+            logger.info('Restarting schedule loop with new interval')
+            self._restart_loop()
 
     @property
     def schedule_status(self):

--- a/dripline/core/spime.py
+++ b/dripline/core/spime.py
@@ -64,9 +64,7 @@ class Spime(Endpoint, Scheduler):
                 logger.error('Cannot define both log_interval and loop_interval for Spime <{}>'.format(kwargs['name']))
             kwargs['schedule_interval'] = kwargs.pop('log_interval')
 
-        # Endpoint stuff
         Endpoint.__init__(self, **kwargs)
-        # Scheduler stuff
         Scheduler.__init__(self, **kwargs)
 
         self.alert_routing_key=alert_routing_key + '.' + self.name
@@ -88,6 +86,22 @@ class Spime(Endpoint, Scheduler):
             self.on_set = _log_on_set_decoration(self, super(Spime, self))
         else:
             self.on_set = super(Spime, self).on_set
+
+    # Redirect logging_status to scheduler schedule_status for backwards compatibility
+    @property
+    def logging_status(self):
+        return self.schedule_status
+    @logging_status.setter
+    def logging_status(self, value):
+        self.schedule_status = value
+
+    # Redirect log_interval to scheduler schedule_interval for backwards compatibility
+    @property
+    def log_interval(self):
+        return self.schedule_interval
+    @log_interval.setter
+    def log_interval(self, value):
+        self.schedule_interval = value
 
     @property
     def max_interval(self):

--- a/dripline/core/spime.py
+++ b/dripline/core/spime.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import datetime
 import logging
 import functools
 
@@ -47,33 +48,96 @@ class Spime(Endpoint, Scheduler):
 
     def __init__(self,
                  log_on_set=False,
+                 max_interval=0,
+                 max_fractional_change=0,
+                 alert_routing_key='sensor_value',
                  **kwargs
                 ):
         '''
         log_on_set (bool): flag to enable logging the new value whenever a new one is set
+        max_interval (float): If > 0, any log event exceding this number of seconds since the last broadcast will trigger a broadcast.
+        max_fractional_change (float): If > 0, any log event which produces a value which differs from the previous value by more than this amount (expressed as a fraction, ie 10% change is 0.1) will trigger a broadcast
+        alert_routing_key (str): routing key for the alert message send when broadcasting a logging event result. The default value of 'sensor_value' is valid for DataLoggers which represent physical quantities being stored to the slow controls database tables
         '''
+        if 'log_interval' in kwargs:
+            if 'schedule_interval' in kwargs:
+                logger.error('Cannot define both log_interval and loop_interval for Spime <{}>'.format(kwargs['name']))
+            kwargs['schedule_interval'] = kwargs.pop('log_interval')
+
         # Endpoint stuff
         Endpoint.__init__(self, **kwargs)
         # Scheduler stuff
         Scheduler.__init__(self, **kwargs)
-        self.get_value = self.on_get
 
+        self.alert_routing_key=alert_routing_key + '.' + self.name
+        self._max_interval = max_interval
+        self._max_fractional_change = max_fractional_change
+        self._last_log_time = None
+        self._last_log_value = None
         self._log_on_set = log_on_set
         if log_on_set:
             self.on_set = _log_on_set_decoration(self, self.on_set)
+
     @property
     def log_on_set(self):
         return self._log_on_set
     @log_on_set.setter
     def log_on_set(self, value):
-        #if bool(value) != bool(self._log_on_set):
-        #    return
         self._log_on_set = bool(value)
         if self._log_on_set:
             self.on_set = _log_on_set_decoration(self, super(Spime, self))
         else:
             self.on_set = super(Spime, self).on_set
 
+    @property
+    def max_interval(self):
+        return self._max_interval
+    @max_interval.setter
+    def max_interval(self, value):
+        value = float(value)
+        if value < 0:
+            raise ValueError('max log interval cannot be < 0')
+        self._max_interval = value
+
+    @property
+    def max_fractional_change(self):
+        return self._max_fractional_change
+    @max_fractional_change.setter
+    def max_fractional_change(self, value):
+        value = float(value)
+        if value < 0:
+            raise ValueError('fractional change cannot be < 0')
+        self._max_fractional_change = value
+
     @staticmethod
     def store_value(alert, severity):
+        '''
+        This method automatically overridden in Spimescape add_endpoint
+        '''
         logger.error("Should be logging (value,severity): ({},{})".format(alert, severity))
+
+    def scheduled_action(self):
+        '''
+        Override Scheduler method with Spime-specific get and log
+        '''
+        result = self.on_get()
+        if result is None:
+            logger.warning('Spime scheduled get returned None for <{}>'.format(self.name))
+        # Create float cast of value_raw for max_fractional_change test
+        try:
+            this_value = float(result['value_raw'])
+        except (TypeError, ValueError):
+            this_value = False
+        # Check if this value should be logged
+        if self._last_log_value is None:
+            logger.debug("log b/c no last log")
+        elif (datetime.datetime.utcnow() - self._last_log_time).seconds > self._max_interval:
+            logger.debug('log b/c too much time')
+        elif this_value and (abs(self._last_log_value - this_value)/self._last_log_value)>self.max_fractional_change:
+            logger.debug('log b/c change is too large')
+        else:
+            logger.debug('no log condition met, not logging')
+            return
+        self.store_value(result, severity=self.alert_routing_key)
+        self._last_log_time = datetime.datetime.utcnow()
+        self._last_log_value = this_value


### PR DESCRIPTION
Retain only schedule-specific items, logger-specific pieces dumped into spime, provider updated to reflect new split.  Verified to work in the T2 zone.

It still doesn't neatly handle the pinger startup, but it does most of the other things we want.

It will require a coordinated release of dragonfly (to update the pinger code) and hardware (to update every setup_call naming); these are staged.  I considered rerouting on_set for logging_status of provider to schedule_status, but thought that would just prolong the pain.