### PR TITLE
solving broadcast returns in provider

### DIFF
--- a/dripline/core/provider.py
+++ b/dripline/core/provider.py
@@ -134,6 +134,9 @@ class Provider(Endpoint):
         if lockout_key:
             request.lockout_key = lockout_key
         reply = self.service.send_request(**request_kwargs)
+        # broadcast commands should not expect a well-formatted response dict, but rather a variable-length list of response dicts
+        if target.startswith('broadcast'):
+            return
         if (not reply.retcode == 0) and (not ignore_retcode):
             raise exception_map[reply.retcode](reply.return_msg, result=reply.payload)
         return reply.payload


### PR DESCRIPTION
Related to issue #21.

When issuing a provider.cmd('broadcast',...), the return will be a list of dict, whereas provider's `_send_request` expects a dict with relevant keys.  This causes the service originating the cmd to crash.  However, broadcasts in the code should be designed to not check retcodes of their action.

A higher-level fix could be implemented in service's `send_request`, but this would interfere with the command-line ability to get and check broadcast responses.  This may be desired behavior, as in the case of `broadcast.ping`:
```
$ dragonfly cmd broadcast.ping -b higgsino.physics.ucsb.edu -v
broadcast.ping(ret:0): [slow_control_snapshot_service]-> {u'values': [None]}
broadcast.ping(ret:0): [slow_control_snapshot_service2]-> {u'values': [None]}
```

This fix is very case-specific.  It will not catch generic returns of lists (none are expected), but only the specific case of a broadcast; it will ignore the broadcast return even if it consists of only a single valid dict.