### PR TITLE
regaining built-in symtable of asteval for calibration

### DIFF
--- a/dripline/core/endpoint.py
+++ b/dripline/core/endpoint.py
@@ -45,11 +45,7 @@ def calibrate(cal_functions=None):
             if self._calibration is None:
                 pass
             elif isinstance(self._calibration, str):
-                #globals = {
-                #           "math": math,
-                #          }
-                locals = cal_functions
-                evaluator = asteval.Interpreter(symtable=locals)
+                evaluator = asteval.Interpreter(usersyms=cal_functions)
                 if isinstance(val_dict['value_raw'],float):
                     eval_str = self._calibration.format(val_dict['value_raw'])
                 else:


### PR DESCRIPTION
As-written we wipe the existing symtable from asteval by overwriting it, proposed would keep existing table (483 elements!) and update with our cal_functions (I think there's a name conflict so we overwrite the 'print' entry, don't care).

+ we can use log and other useful math in calibrate functions and not explicitly define in dripline the functions to keep
- overhead of the symtable

then a little cleaning of the surrounding lines