### PR TITLE
crash on failed exclusive locks

### DIFF
--- a/dripline/core/service.py
+++ b/dripline/core/service.py
@@ -199,8 +199,10 @@ class Service(Provider):
         :param str reply_text: The text reason the channel was closed
 
         """
-        logger.warning('Channel {} was closed: ({}) {}'.format(
-                       int(channel), reply_code, reply_text))
+        if reply_code == 405:
+            logger.error('crashing because unable to obtain exclusive lock')
+            raise exceptions.DriplineAMQPError(reply_text)
+        logger.warning('Channel {} was closed: ({}) {}'.format( int(channel), reply_code, reply_text))
         self._connection.close()
 
     def setup_exchange(self, exchange_name):


### PR DESCRIPTION
Currently, when a channel is unable to provide an exclusive lock there is no exception and the service sleeps ~5 seconds and then tries again. This is problematic because as a result the desired setup calls are not executed and services do not spin up in the desired/expected state.

Rather than doing the above, this solution is to simply crash the service. It is then on the user/process management to restart (hopefully after the exclusive lock conflict is resolved).

Note: This has been merged on dripline-org's dripline-python and tagged at v3.7.3, it would be ideal if we could get this in to project8's repo with the same version.